### PR TITLE
Add ticket owner/assigned-to filter

### DIFF
--- a/src/components/Filters.js
+++ b/src/components/Filters.js
@@ -58,6 +58,17 @@ export default function Filters() {
 				fuzziness={1}
 				URLParams
 			/>
+			<DataSearch
+				className="filter owner"
+				componentId="owner"
+				dataField="owner"
+				title="Assigned to:"
+				filterLabel="Assigned to"
+				placeholder="username"
+				autosuggest
+				fuzziness={1}
+				URLParams
+			/>
 		</div>
 	);
 }

--- a/src/components/Results.js
+++ b/src/components/Results.js
@@ -48,7 +48,7 @@ export default function Results( props ) {
 				componentId="SearchResults"
 				from={0}
 				size={20}
-				react={{and:["status","reporter","search", "status", "focuses", "type", "component", "milestone"]}}
+				react={{and:["component", "focuses", "milestone", "owner", "reporter", "search", "status", "type"]}}
 				onData={(data) => <TicketListItem showTicket={props.showTicket} ticket={data} key={data._id} showDesc={props.showDesc} /> }
 				URLParams
 				pagination


### PR DESCRIPTION
Adds a filter field for ticket owner/assignee that matches the "Reported by" field. 

Neither of these fields are currently tied to the other fields, so the suggested options are not narrowed down by the other filters. This was done on purpose since they are more open-entry fields, but I'm open to changing that. 

Closes #6