### PR TITLE
 Solve long ticket update wrapping issue (issue 7)

### DIFF
--- a/src/components/TicketUpdates.css
+++ b/src/components/TicketUpdates.css
@@ -9,6 +9,10 @@
     z-index: -1;
     width: 40px;
 } */
+.update {
+    display: inline-flex;
+}
+
 .ticket-updates {
 	position: relative;
 }

--- a/src/components/Update.js
+++ b/src/components/Update.js
@@ -7,6 +7,8 @@ import './Update.css';
 export default function Update( { children, update, className } ) {
 	return <div className={`update ${ update.update_type } ${ className }`}>
 		<UpdateIcon update={update} />
-		{ children }
+		<div className={`update-content`}>
+			{ children }
+		</div>
 	</div>;
 }


### PR DESCRIPTION
I found that the problem with the long tickets update that wrapped can be solved by adding a `div` markup just after the svg icon and adding an `inline-flex` to the parent div.
But I'm not really sure of the code I added in Update.js since, I'm still new to React.